### PR TITLE
Add pre-commit, fix 'ploting' typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,126 @@
+---
+files: ^(.*\.(py|json|md|sh|yaml|cfg|txt))$
+exclude: ^(\.[^/]*cache/.*|.*/_user.py)$
+repos:
+  - repo: https://github.com/executablebooks/mdformat
+    # Do this before other tools "fixing" the line endings
+    rev: 0.7.14
+    hooks:
+      - id: mdformat
+        name: Format Markdown
+        entry: mdformat  # Executable to run, with fixed options
+        language: python
+        types: [markdown]
+        args: [--wrap, '78', --number]
+        additional_dependencies:
+          - mdformat-toc
+          - mdformat-beautysh
+          # -mdformat-shfmt
+          # -mdformat-tables
+          - mdformat-config
+          - mdformat-black
+          - mdformat-web
+          - mdformat-gfm
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: check-yaml
+        args: [--unsafe]
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-json
+      - id: mixed-line-ending
+      - id: check-builtin-literals
+      - id: check-ast
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
+      - id: check-docstring-first
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      # - id: check-toml
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.26.3
+    hooks:
+      - id: yamllint
+        args:
+          - --no-warnings
+          - -d
+          - '{extends: relaxed, rules: {line-length: {max: 90}}}'
+  - repo: https://github.com/lovesegfault/beautysh.git
+    rev: v6.2.1
+    hooks:
+      - id: beautysh
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.34.0
+    hooks:
+      - id: pyupgrade
+  - repo: https://github.com/psf/black
+    rev: 22.6.0
+    hooks:
+      - id: black
+#  - repo: https://github.com/Lucas-C/pre-commit-hooks-bandit
+#    rev: v1.0.6
+#    hooks:
+#      - id: python-bandit-vulnerability-check
+#        args: [--skip, 'B101,B311', --recursive, .]
+#
+#  - repo: https://github.com/fsouza/autoflake8
+#    rev: v0.3.2
+#    hooks:
+#      - id: autoflake8
+#        args:
+#          - -i
+#          - -r
+#          - --expand-star-imports
+#          - .
+#  - repo: https://github.com/PyCQA/flake8
+#    rev: 4.0.1
+#    hooks:
+#      - id: flake8
+#        additional_dependencies:
+#          - pyproject-flake8==0.0.1a2
+#          - flake8-bugbear==22.1.11
+#          - flake8-comprehensions==3.8.0
+#          - flake8_2020==1.6.1
+#          - mccabe==0.6.1
+#          - pycodestyle==2.8.0
+#          - pyflakes==2.4.0
+#  - repo: https://github.com/PyCQA/isort
+#    rev: 5.10.1
+#    hooks:
+#      - id: isort
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        args:
+          # - --builtin=clear,rare,informal,usage,code,names,en-GB_to_en-US
+          - --builtin=clear,rare,informal,usage,code,names
+          - --ignore-words-list=hass,master
+          - --skip="./.*"
+          - --quiet-level=2
+  - repo: https://github.com/pre-commit/mirrors-pylint
+    rev: v3.0.0a5
+    hooks:
+      - id: pylint
+        args:
+          - --reports=no
+          - --py-version=3.7
+        #exclude: ^$
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.961
+    hooks:
+      - id: mypy
+        args:
+          - --ignore-missing-imports
+          - --install-types
+          - --non-interactive
+          - --check-untyped-defs
+          - --show-error-codes
+          - --show-error-context
+        additional_dependencies:
+          - zigpy==0.43.0

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ files.
 PCBs are plotted into PDF files, one for each layer. Then ImageMagick is used
 to compare the layers and JPG files are generated. The JPGs are finally
 assembled into one PDF file and the default PDF reader is invoked.
+
 All the intermediate files are generated in the system temporal directory and
 removed as soon as the job is finished. You can cache the layers PDFs
 specifying a cache directory and keep the resulting diff images specifying an
@@ -22,87 +23,133 @@ resource' command.
 ## Dependencies
 
 In order to run the scripts you need:
-* Python 3.5 or newer
-* KiCad 5.1 or newer
-* Python3 wxWidgets (i.e. python3-wxgtk4.0)
-* ImageMagick tools (i.e. imagemagick Debian package)
-* pdftoppm tool (i.e. poppler-utils Debian package)
-* xdg-open tool (i.e. xdg-utils Debian package)
+
+- Python 3.5 or newer
+- KiCad 5.1 or newer
+- Python3 wxWidgets (i.e. python3-wxgtk4.0)
+- ImageMagick tools (i.e. imagemagick Debian package)
+- pdftoppm tool (i.e. poppler-utils Debian package)
+- xdg-open tool (i.e. xdg-utils Debian package)
 
 In a Debian/Ubuntu system you'll get them running:
 
-```$ sudo apt-get install python3 kicad python3-wxgtk4.0 imagemagick poppler-utils xdg-utils```
+```shell
+$ sudo apt-get install python3 kicad python3-wxgtk4.0 imagemagick poppler-utils xdg-utils
+```
 
-Note: if you are using Debian, or some derived distro like Ubuntu, you can find a Debian package in the releases section.
+Note: if you are using Debian, or some derived distro like Ubuntu, you can
+find a Debian package in the releases section.
 
 ## Standalone use
 
 1. As root run:
-```
+
+```shell
 # make install
 ```
 
-The scripts will be copied to */usr/local/bin*. If you want to install the scripts in */usr/bin* run
+The scripts will be copied to */usr/local/bin*. If you want to install the
+scripts in */usr/bin* run
 
-```
+```shell
 # make prefix=/usr install
 ```
 
-Note: if you are using Debian, or some derived distro like Ubuntu, you can find a Debian package in the releases section.
+Note: if you are using Debian, or some derived distro like Ubuntu, you can
+find a Debian package in the releases section.
 
 ## Git plug-in
 
 1. Install the scripts
-2. To initialize a repo just run the *kicad_pcb-diff-init.py* script from the root of the repo.
-This will configure the repo to read extra configuration from the *.gitconfig* file.
-It will also associate the *kicad_pcb* file extension with the *kicad_pcb-git-diff.py* script.
-3. The initialization script will create a list of layers to be excluded in the *.kicad_pcb-git-diff* file.
-Review this file and adjust it to your needs. Lines starting with *#* will be ignored.
+2. To initialize a repo just run the *kicad_pcb-diff-init.py* script from the
+   root of the repo.\
+   This will configure the repo to read extra configuration
+   from the *.gitconfig* file.\
+   It will also associate the *kicad_pcb* file
+   extension with the *kicad_pcb-git-diff.py* script.
+3. The initialization script will create a list of layers to be excluded in
+   the *.kicad_pcb-git-diff* file.\
+   Review this file and adjust it to your
+   needs. Lines starting with *#* will be ignored.
 
 Once configured the tool will be used every time you do a diff using *git*.
 
 # Usage
 
-The *kicad_pcb-git-diff.py* is a plug-in for *git* so you just need to configure *git* and then it becomes transparent. If you need to create a diff between two files outside *git* you can use the *kicad_pcb-diff.py* script.
+The *kicad_pcb-git-diff.py* is a plug-in for *git* so you just need to
+configure *git* and then it becomes transparent. If you need to create a diff
+between two files outside *git* you can use the *kicad_pcb-diff.py* script.
 
-You have to provide the name of the two PCBs to be compared. The additional command line options are:
+You have to provide the name of the two PCBs to be compared. The additional
+command line options are:
 
 ## -h
+
 Shows a very brief list of the available options.
 
 ## --help
+
 Shows a more detailed list of the available options.
 
 ## -v/--verbose
-Increases the level of verbosity. The default is a quite, specifying one level (*-v*) you'll get information messages about what's going on. If you increase the level to two (*-vv*) you'll get very detailed information, most probably useful only to debug problems.
+
+Increases the level of verbosity. The default is a quite, specifying one level
+(*-v*) you'll get information messages about what's going on. If you increase
+the level to two (*-vv*) you'll get very detailed information, most probably
+useful only to debug problems.
 
 ## --version
+
 Print the script version, copyright and license.
 
 ## --cache_dir
-The PCB files are plotted to PDF files. One PDF file for layer. To avoid plotting them over and over you can specify a cache directory to store the PDFs.
+
+The PCB files are plotted to PDF files. One PDF file for layer. To avoid
+plotting them over and over you can specify a cache directory to store the
+PDFs.
 
 ## --output_dir
-Two seconds after invoking the PDF viewer the output files are removed. If you want to keep them for later review, or two seconds isn't enough for your system, you can specify a directory to store the generated files.
+
+Two seconds after invoking the PDF viewer the output files are removed. If you
+want to keep them for later review, or two seconds isn't enough for your
+system, you can specify a directory to store the generated files.
 
 ## --resolution
-The PDF files are converted to bitmaps to be compared. The default resolution for these bitmaps is 150 DPIs. This is a compromise between speed and legibility. For faster compares you can use a smaller resolution. For detailed comparison you can use a higher resolution. Be careful because the time is increased exponentially. You can also run out of resources. In particular ImageMagick defines some limits to the disk used for operations. These limits can be very low for default installations. You can consult the limits using the following command:
 
-```identify -list resource```
- 
- Consult ImageMagick documentation in order to increase them.
- 
+The PDF files are converted to bitmaps to be compared. The default resolution
+for these bitmaps is 150 DPIs. This is a compromise between speed and
+legibility. For faster compares you can use a smaller resolution. For detailed
+comparison you can use a higher resolution. Be careful because the time is
+increased exponentially. You can also run out of resources. In particular
+ImageMagick defines some limits to the disk used for operations. These limits
+can be very low for default installations. You can consult the limits using
+the following command:
+
+`identify -list resource`
+
+Consult ImageMagick documentation in order to increase them.
+
 ## --old_pcb_hash
-The plotted PDF files for each layer are stored in the cache directory using a SHA1 of the PCB file as name for the directory. You can specify another hash here to identify the old PCB file. 
-The *git* plug-in uses the hash provided by *git* instead of the SHA1 for the file.
+
+The plotted PDF files for each layer are stored in the cache directory using a
+SHA1 of the PCB file as name for the directory. You can specify another hash
+here to identify the old PCB file.
+
+The *git* plug-in uses the hash provided by *git* instead of the SHA1 for the
+file.
 
 ## --new_pcb_hash
-This is the equivalent of the *--old_pcb_hash* option used for the new PCB file.
+
+This is the equivalent of the *--old_pcb_hash* option used for the new PCB
+file.
 
 ## --exclude
-Specifies the name of a file containing a list of layers to be excluded. Each line of the file is interpreted as a layer name. An example for this file could be:
 
-```
+Specifies the name of a file containing a list of layers to be excluded. Each
+line of the file is interpreted as a layer name. An example for this file
+could be:
+
+```raw
 B.Adhes
 F.Adhes
 Cmts.User
@@ -112,17 +159,24 @@ Edge.Cuts
 Margin
 ```
 
-Note that when using the *git* plug-in the script looks for a file named *.kicad_pcb-git-diff* at the root of the repo.
+Note that when using the *git* plug-in the script looks for a file named
+*.kicad_pcb-git-diff* at the root of the repo.
 
-Using this you can reduce the time wasted computing diffs for empty or useless layers.
+Using this you can reduce the time wasted computing diffs for empty or useless
+layers.
 
 ## --no_reader
-Use it to avoid invoking the default PDF viewer. Note that you should also provide an output directory using *--output_dir*.
+
+Use it to avoid invoking the default PDF viewer. Note that you should also
+provide an output directory using *--output_dir*.
 
 The default PDF reader is invoked using *xdg-open*
 
 # Credits and notes
 
-* This script is strongly based on Jesse Vincent [work](https://github.com/obra/kicad-tools).
-* I borrowed the command to compare two images from Brecht Machiels. In particular from his [diffpdf.sh](https://gist.github.com/brechtm/891de9f72516c1b2cbc1) tool.
-* I'm not a Python programmer, stackoverflow helps me ... 
+- This script is strongly based on Jesse Vincent
+  [work](https://github.com/obra/kicad-tools).
+- I borrowed the command to compare two images from Brecht Machiels. In
+  particular from his
+  [diffpdf.sh](https://gist.github.com/brechtm/891de9f72516c1b2cbc1) tool.
+- I'm not a Python programmer, stackoverflow helps me ...

--- a/kicad-diff.py
+++ b/kicad-diff.py
@@ -89,7 +89,7 @@ def GenPCBImages(file, file_hash, hash_dir, file_no_ext):
         name_pdf = '%s%s%s.pdf' % (hash_dir, sep, layer_rep)
         # Create the PDF, or use a cached version
         if not isfile(name_pdf):
-            logger.info('Ploting %s layer' % layer)
+            logger.info('Plotting %s layer' % layer)
             pctl.SetLayer(i)
             pctl.OpenPlotfile(layer, PLOT_FORMAT_PDF, layer)
             pctl.PlotLayer()
@@ -108,7 +108,7 @@ def GenSCHImage(file, file_hash, hash_dir, file_no_ext):
     name_pdf = '%s%sSchematic.pdf' % (hash_dir, sep)
     # Create the PDF, or use a cached version
     if not isfile(name_pdf):
-        logger.info('Ploting the schematic')
+        logger.info('Plotting the schematic')
         cmd = ['eeschema_do', 'export', '--file_format', 'pdf', '--monochrome', '--no_frame', '--output_name', name_pdf, file, '.']
         logger.debug('Executing: '+str(cmd))
         call(cmd)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,10 @@ safe = True
 quiet = True
 line-length = 127
 
+[isort]
+profile = black
+line_length = 127
+
 [autoflake8]
 in-place = True
 recursive = True
@@ -48,3 +52,15 @@ check_untyped_defs = True
 show_error_codes = True
 show_error_context = True
 # additional_dependencies = module==version
+
+[pylint.MESSAGES CONTROL]
+disable = invalid-name, unused-argument, broad-except, missing-docstring, fixme,
+          consider-using-f-string,
+          too-many-branches, too-many-statements, too-many-arguments, protected-access,
+          import-error, too-many-locals, import-outside-toplevel,
+          logging-fstring-interpolation, line-too-long,
+          duplicate-code,
+          logging-not-lazy, wrong-import-order,
+
+[pylint.FORMAT]
+max-line-length = 127


### PR DESCRIPTION
Added pre-commit setup, formatted README.md and corrected 'Ploting' into 'Plotting' (identified with codespell).

Reduced pylint notifications quite a bit, leaving just a few that I'ld fix.

I commented several targets in .pre-commit-config.yaml that modify the python code, except black (setup.cfg has rules for some of these targets).
